### PR TITLE
Fix backup not starting

### DIFF
--- a/cpp/workers/backupmanager.cpp
+++ b/cpp/workers/backupmanager.cpp
@@ -86,6 +86,8 @@ void BackupManager::initialize()
     // initialize next backup checking
     connect(&m_timer, &QTimer::timeout, this, &BackupManager::doBackup);
     updateInterval();
+
+    start();
 }
 
 BackupManager::Data &BackupManager::data()


### PR DESCRIPTION
Backup timer is only running when it recovers for backup.

In case I restart PC, get a crash or close process we will have outdated backup file.